### PR TITLE
Modify the lesson to explain basic Spring Security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Let's create a new Spring project to demonstrate the Spring security features.
    containing the Spring Boot Project.
 5. Unzip the archive and open it in IntelliJ or a preferred code editor.
 
-![spring-security-project-initializr](https://curriculum-content.s3.amazonaws.com/spring-mod-2/security/spring-initialzr-security-project.png)
+![spring-security-project-initializr](https://curriculum-content.s3.amazonaws.com/spring-mod-2/security2/spring-initialzr-security-project.png)
 
 Once you have created the new project, let's create a few packages and classes.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Base API Implementation
+# Spring Security Introduction
 
 ## Learning Goals
 
@@ -7,141 +7,174 @@
 
 ## Why Security?
 
-The sample service we've stood up so far is simplistic in 2 ways:
-
-1. It returns a single string with very little processing. In real life, each
-   service will be responsible for more business logic (functionality) and will
-   return its results in some type of structured format, most likely JSON (
-   JavaScript Object Notation) or XML.
-2. It is open to the entire world to see access. That is, once it's deployed on
-   a system that is exposed to the internet, anyone with access to the internet
-   would be able to access our service. This is desirable in some cases (many
-   APIs are public by nature), but there are also a lot of scenarios in which we
-   might want to control access our APIs.
+So far, the APIs we have stood up so far are open to the entire world to
+access. That is, once we deploy the application on a system that is exposed to
+the internet, anyone with access to the internet would be able to access our
+service. This is desirable in some cases (many APIs are public by nature), but
+there are also a lot of scenarios in which we might want to control access our
+APIs.
 
 When we want to control access to our APIs, there are 2 fundamental ways in
 which this is achieved:
 
-1. Authentication: this is the process of validating that you are who you say
-   you are
-2. Authorization: this is the process of validating that your user is authorized
-   to perform the specific action they are trying to perform
+1. **Authentication**: This is the process of validating that a user is who
+   they claim to be.
+2. **Authorization**: this is the process of validating that a user is
+   authorized to perform the specific action they are trying to perform.
 
-You can implement authentication without authorization: it basically means all
-users in your system have the same rights, and all you care about is that you're
+We can implement authentication without authorization. That basically means all
+users in the system have the same rights, and all we care about is that we are
 able to recognize who they are (i.e. they authenticate themselves).
 
-You cannot implement authorization without authentication, because you have to
-validate that a user is who they say they are before you can actually worry
-about whether they're allowed to perform the specific action they are trying to
-perform.
+However, we cannot implement authorization without authentication, because
+we have to validate that a user is who they say they are before we can actually
+worry about whether they're allowed to perform the specific action they are
+trying to perform.
 
 Let's look at how to implement both Authentication (AuthN) and Authorization
-(AuthZ)
+(AuthZ).
 
-## Base API Implementation
+## Create a Spring Security Project
 
-Let's revisit our sample API implementation from the previous section.
+Let's create a new Spring project to demonstrate the Spring security features.
 
-Here is the controller:
+1. Go to [https://start.spring.io/](https://start.spring.io/).
+2. Select the project properties.
+    1. Select "Maven Project", as we will use Maven as the build tool.
+    2. Select "Java" as the language.
+    3. Select the most recent version of Spring Boot 2. (Make sure it does not
+       have "SNAPSHOT" listed after it.)
+    4. Change the "Artifact" metadata field to "spring-security-demo". (This
+       will update the "Name" and "Package name" metadata fields too).
+    5. Change the "Description" metadata field to "Demo for Spring Security".
+    6. Select the appropriate Java JDK version.
+3. Add dependencies.
+    1. Click "ADD DEPENDENCIES".
+    2. Search for "spring web".
+    3. Select "Spring Web" from the list.
+    4. Click on "ADD DEPENDENCIES" again and add  "Lombok" from the list.
+    5. Click on "ADD DEPENDENCIES" again and add "Spring Security" from the list.
+    6. Click on "ADD DEPENDENCIES" again and add "Oauth2 Client" from the list.
+    7. Click on "ADD DEPENDENCIES" again and add "Oauth2 Resource Server" from
+       the list.
+4. Click on the "Generate" button on the bottom. This will download a zip file
+   containing the Spring Boot Project.
+5. Unzip the archive and open it in IntelliJ or a preferred code editor.
+
+![spring-security-project-initializr](https://curriculum-content.s3.amazonaws.com/spring-mod-2/security/spring-initialzr-security-project.png)
+
+Once you have created the new project, let's create a few packages and classes.
+
+Create a package called `controller` and `config` under the
+`com.example.springsecuritydemo` directory. In the `controller` directory,
+create a Java class called `DemoController`. In the `config` directory, create
+a Java class called `SecurityConfiguration`.
+
+Consider the following project structure and ensure yours looks the same:
+
+```text
+├── HELP.md
+├── mvnw
+├── mvnw.cmd
+├── pom.xml
+└── src
+    ├── main
+    │   ├── java
+    │   │   └── com
+    │   │       └── example
+    │   │           └── springsecuritydemo
+    │   │               ├── SpringSecurityDemoApplication.java
+    │   │               ├── controller
+    │   │               │   └── DemoController.java
+    │   │               └── config
+    │   │                   └── SecurityConfiguration.java
+    │   └── resources
+    │       ├── application.properties
+    │       ├── static
+    │       └── templates
+    └── test
+        └── java
+            └── org
+                └── example
+                    └── springsecuritydemo
+                        └── SpringSecurityDemoApplicationTests.java
+```
+
+Once the project structure is set up, add the following code to the
+`DemoController` class:
 
 ```java
-package com.flatiron.spring.FlatironSpring;
+package com.example.springsecuritydemo.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class HelloController {
+public class DemoController {
 
     @GetMapping("/hello")
-    public String hello(@RequestParam(name = "targetName", defaultValue = "Stephanie") String name) {
+    public String hello(@RequestParam(defaultValue = "person") String name) {
         return String.format("Hello %s", name);
     }
-
 }
 ```
 
-Here is the custom security configuration we put in place to work around the
-default login functionality that Spring Boot puts in place (depending on the
-version of Spring Boot you're using):
+## Running the Application
 
-```java
-package com.flatiron.spring.FlatironSpring;
+As we can see, we've created a very simple Spring Boot application with only one
+endpoint defined in our controller class. Let's go ahead and run the application
+now:
 
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+![user-generated-password](https://curriculum-content.s3.amazonaws.com/spring-mod-2/security/application-user-generated-security-password-intellij.png)
 
-@Configuration
-@EnableWebSecurity
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+Now that we have included the Spring Security dependency in our project, Spring
+Security has auto-generated a user password for us. By default, all the
+endpoints are now protected under Spring Security.
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-      http.authorizeRequests()
-              .anyRequest().permitAll();
-    }
-}
-```
+As noted in the console message, the auto-generated password that has been given
+to us, it for development and testing purposes only. Later on, we'll learn how to
+configure this for an application running in production.
 
-Let's take a close look at what this `SecurityConfiguration` class does:
+Since we only have one endpoint, let's open up Postman and try to send the GET
+request. Make sure the headers include "Content-Type: application/json" before
+sending the request as well:
 
-- The `@Configuration` and `@EnableWebSecurity` annotations tell the Spring
-  Framework that this class should be used for configuring the security of this
-  Spring application
-- The `'configure()` method:
-  - Takes an `HttpSecurity` object as a parameter
-  - Calls the `authorizeRequests()` method to specify how different requests
-    must be authorized
+![401-unauthorized-attempt](https://curriculum-content.s3.amazonaws.com/spring-mod-2/security/unauthorized-postman.PNG)
 
-## Adding Basic Security
+Notice what we get back is a "401 Unauthorized" status message. This is because
+we are not authenticated and our endpoint, by default with the Spring Security
+dependency, is now secured.
 
-Let's remove the `configure()` method from the `SecurityConfiguration` class:
+So how can we reach our endpoint now?
 
-```java
-package com.flatiron.spring.FlatironSpring;
+In Postman, navigate to the "Authorization" tab. Once there, choose "Basic Auth"
+from the "Type" dropdown:
 
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+![basic-auth](https://curriculum-content.s3.amazonaws.com/spring-mod-2/security/postman-basic-auth.PNG)
 
-@Configuration
-@EnableWebSecurity
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
-}
-```
+When we select "Basic Auth", we will see a prompt for a username and password
+off to the right. The default username is "user" and then we'll make use of the
+auto-generated password that Spring provided us with in the console.
 
-That will put the default Spring Framework security implementation into effect
-again. Let's have a look at what that does to our endpoint:
+![basic-auth-credentials](https://curriculum-content.s3.amazonaws.com/spring-mod-2/security/postman-basic-auth-credentials.PNG)
 
-![Spring Framework default simple authentication](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-testing-simple-auth.png)
+It should be noted that the password here in this lesson is different from your
+password if you are following along with this lesson. This is because each
+password is unique and will change with every time we restart the application.
+In the screenshot above, we have selected "Show Password" just to demonstrate
+that the password is the same as the auto-generated password we saw in our
+console earlier. You do not have to have this box checked - as this was for
+demonstration purposes.
 
-Note: if the default Spring Framework security is not in place for your sample
-project, you may need to add spring security to your classpath explicitly, which
-can be done as follows:
+By performing these steps here, we are now able to pass a set of credentials
+along with our GET request to say that we are authenticated and now authorized
+to view the endpoint. Let's send our GET request again and see what happens:
 
-- Gradle: Add the following dependencies to your `build.gradle` file:
+![hit-hello-endpoint](https://curriculum-content.s3.amazonaws.com/spring-mod-2/security/postman-hello-person.PNG)
 
-```json
-dependencies {
-        // ...
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-}
-```
+This process of authentication is known as **HTTP Basic**.
 
-- Maven: Add the following dependencies to your `pom.xml` file:
+## References
 
-```xml
-<dependencies>
-	<!-- ... -->
-	<dependency>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-security</artifactId>
-	</dependency>
-</dependencies>
-```
-
-Now that we have the default implementation in place, let's look at ways to
-customize it in the next section.
+- [Spring Security Fundamentals - Lesson 1 - First Steps](https://www.youtube.com/watch?v=nSu9ElsnNtY&list=PLEocw3gLFc8X_a8hGWGaBnSkPFJmbb8QP)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ trying to perform.
 Let's look at how to implement both Authentication (AuthN) and Authorization
 (AuthZ).
 
-## Create a Spring Security Project
+## Code Along: Create a Spring Security Project
 
 Let's create a new Spring project to demonstrate the Spring security features.
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ Let's create a new Spring project to demonstrate the Spring security features.
     3. Select "Spring Web" from the list.
     4. Click on "ADD DEPENDENCIES" again and add  "Lombok" from the list.
     5. Click on "ADD DEPENDENCIES" again and add "Spring Security" from the list.
-    6. Click on "ADD DEPENDENCIES" again and add "Oauth2 Client" from the list.
-    7. Click on "ADD DEPENDENCIES" again and add "Oauth2 Resource Server" from
-       the list.
 4. Click on the "Generate" button on the bottom. This will download a zip file
    containing the Spring Boot Project.
 5. Unzip the archive and open it in IntelliJ or a preferred code editor.

--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@
 
 ## Why Security?
 
-So far, the APIs we have stood up so far are open to the entire world to
-access. That is, once we deploy the application on a system that is exposed to
-the internet, anyone with access to the internet would be able to access our
-service. This is desirable in some cases (many APIs are public by nature), but
-there are also a lot of scenarios in which we might want to control access our
-APIs.
+So far, the APIs we have stood up are open to the entire world to access. That
+is, once we deploy the application on a system that is exposed to the internet,
+anyone with access to the internet would be able to access our service. This is
+desirable in some cases (many APIs are public by nature), but there are also a
+lot of scenarios in which we might want to control access our APIs.
 
 When we want to control access to our APIs, there are 2 fundamental ways in
 which this is achieved:
@@ -20,7 +19,7 @@ which this is achieved:
 1. **Authentication**: This is the process of validating that a user is who
    they claim to be.
 2. **Authorization**: this is the process of validating that a user is
-   authorized to perform the specific action they are trying to perform.
+   allowed to perform the specific action they are trying to perform.
 
 We can implement authentication without authorization. That basically means all
 users in the system have the same rights, and all we care about is that we are
@@ -84,10 +83,10 @@ Consider the following project structure and ensure yours looks the same:
     │   │       └── example
     │   │           └── springsecuritydemo
     │   │               ├── SpringSecurityDemoApplication.java
-    │   │               ├── controller
-    │   │               │   └── DemoController.java
-    │   │               └── config
-    │   │                   └── SecurityConfiguration.java
+    │   │               ├── config
+    │   │               │   └── SecurityConfiguration.java
+    │   │               └── controller
+    │   │                   └── DemoController.java
     │   └── resources
     │       ├── application.properties
     │       ├── static
@@ -133,7 +132,7 @@ Security has auto-generated a user password for us. By default, all the
 endpoints are now protected under Spring Security.
 
 As noted in the console message, the auto-generated password that has been given
-to us, it for development and testing purposes only. Later on, we'll learn how to
+to us, is for development and testing purposes only. Later on, we'll learn how to
 configure this for an application running in production.
 
 Since we only have one endpoint, let's open up Postman and try to send the GET


### PR DESCRIPTION
This change is being made in the consumer canvas per the conversation on 7/22 to keep the same modules for Blackrock and AWS to streamline.

- Updated lesson to describe the dependencies needed for this lesson and other security lessons.
- Set up a project to use throughout the security lessons.
- Described the default behavior of having Spring Security as a dependency.
- Will address further Spring security configuration in another lesson.